### PR TITLE
update worker in merge_reeb_nodes for > 10x speedup

### DIFF
--- a/src/mainalg.jl
+++ b/src/mainalg.jl
@@ -1053,7 +1053,7 @@ function build_reeb_graph!(obj::gnl,A::sGTDA,M;reeb_component_thd=1,max_iters=10
                     nodes = A.final_components_filtered[rnode]
                     nodes = unique!(nodes)
                     mapping = Dict(i => k for (i,k) in enumerate(nodes))
-		    sub_A = Ar[nodes,:][:,nodes]
+              sub_A = Ar[nodes, nodes]
 		    temp = findnz(sub_A)
                     for (i,j) in zip(temp[1],temp[2])
                          append!(ei,mapping[i])

--- a/src/mainalg.jl
+++ b/src/mainalg.jl
@@ -365,7 +365,7 @@ function graph_clustering(G,bins;component_size_thd=10)
           if length(points) < component_size_thd
                continue
           end
-          Gr = copy(G[points,:][:,points])
+          Gr = copy(G[points,points])
           _,components = find_components(Gr,size_thd = component_size_thd) 
 	     for component in components
 	       push!(graph_clusters[key],[points[node] for node in component])
@@ -380,7 +380,7 @@ function grouping(component_records,Ar,M,slice_columns,curr_level)
      this1 = time()
      for component_id in curr_level
           component = component_records[component_id]
-          G_sub = copy(Ar[component,:][:,component])
+          G_sub = copy(Ar[component,component])
           if slice_columns
                M_sub = copy(M[component,:][:,filter_cols])
           else


### PR DESCRIPTION
I fixed a few performance bottlenecks. Here are brief mentions.

1. I noticed that computing the proper(valid) neighborhood pops up at a few different places, I wrapped up a function called proper_neighborhood to speed up its computation using column-major order access first.
2. Based on proper_neighborhood, I moved the worker inside merge_reeb_nodes outside and pack up a function called closest_proper_neighbor.
3. I fixed a few matrices indexing performance problems.

On some preliminary benchmarks, these modifications provide a 10-100x speedup.